### PR TITLE
More robust sync + basic ownership

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,124 @@
+# Network Play API Documentation
+
+This document provides a detailed reference for the Network Sync API, which allows modders to add multiplayer functionality to Zelda 64: Recompiled mods.
+
+## Core Functions
+
+### Initialization & Connection
+
+#### `void NS_Init()`
+Initializes the network play system. This must be called before using any other networking functions.
+
+- **Parameters:** None
+- **Returns:** None
+- **Usage:** Call this once at the beginning of your mod's execution.
+
+#### `u8 NS_Connect(const char* host)`
+Establishes a connection to the network server.
+
+- **Parameters:**
+  - `host`: String containing the WebSocket URL of the server (e.g., "ws://localhost:9002")
+- **Returns:**
+  - `1` if connection was successful
+  - `0` if connection failed
+- **Usage:** Call after initialization to connect to your network server.
+
+### Session Management
+
+#### `u8 NS_JoinSession(const char* session)`
+Joins a multiplayer session on the server.
+
+- **Parameters:**
+  - `session`: String identifier for the session to join (e.g., "test-session")
+- **Returns:**
+  - `1` if joining was successful
+  - `0` if joining failed
+- **Usage:** Players must join the same session to see and interact with each other.
+
+#### `u8 NS_LeaveSession()`
+Leaves the current multiplayer session.
+
+- **Parameters:** None
+- **Returns:**
+  - `1` if leaving was successful
+  - `0` if leaving failed
+- **Usage:** Call this when you want to disconnect from the current session.
+
+### Actor Synchronization
+
+#### `void NS_SyncActor(Actor* actor, const char* playerID, int isOwnedLocally)`
+Registers an actor for network synchronization.
+
+- **Parameters:**
+  - `actor`: Pointer to the Actor to be synchronized
+  - `playerID`: String identifier for this actor
+    - if actor->id == 0, we use the server defined id (identifies players)
+  - `isOwnedLocally`:
+    - `1` if this client should send updates for this actor
+    - `0` if this client should only receive updates
+- **Returns:** None
+- **Usage:** Call this to start synchronizing an actor across the network.
+
+#### `const char* NS_GetActorNetworkId(Actor *actor)`
+Gets the network identifier for a registered actor.
+
+- **Parameters:**
+  - `actor`: Pointer to the Actor to query
+- **Returns:**
+  - String containing the network ID if the actor is registered
+  - `NULL` if the actor is not registered for synchronization
+- **Usage:** Use to retrieve the unique network identifier for an actor.
+
+### Remote Player Data
+
+#### `u32 NS_GetRemotePlayerIDs(u32 maxPlayers, char* idsBuffer, u32 idBufferSize)`
+Gets a list of connected remote player IDs.
+
+- **Parameters:**
+  - `maxPlayers`: Maximum number of player IDs to retrieve
+  - `idsBuffer`: Buffer to store player IDs (should be at least maxPlayers * idBufferSize)
+  - `idBufferSize`: Size of each player ID string buffer
+- **Returns:** Number of remote player IDs retrieved
+- **Usage:** Call this to get a list of all other players in the session.
+
+#### `u32 NS_GetRemotePlayerData(const char* playerID, void* dataBuffer)`
+Retrieves the most recent data for a specific remote player.
+
+- **Parameters:**
+  - `playerID`: String identifier of the remote player
+  - `dataBuffer`: Buffer to store the player's data (should be a `PlayerSyncData` struct)
+- **Returns:**
+  - `1` if data was successfully retrieved
+  - `0` if data could not be retrieved
+- **Usage:** Call this to get the latest position, animation, and state data for a remote player.
+
+## Data Structures
+
+### `PlayerSyncData`
+Structure containing synchronized data for players.
+
+```c
+typedef struct {
+    Vec3s shapeRotation;  // Actor shape rotation
+    Vec3f worldPosition;  // Actor world position
+
+    // Player Actor properties
+    s8 currentBoots;      // Current boots equipped by the player
+    s8 currentShield;     // Current shield equipped by the player
+    u8 _padding[2];       // Padding for alignment
+    Vec3s jointTable[24]; // Animation joint positions
+    Vec3s upperLimbRot;   // Upper body rotation
+} PlayerSyncData;
+```
+
+## Best Practices
+
+1. **Call NS_Init() early**: Initialize the network system before attempting to use other functions.
+
+2. **Error handling**: Always check return values from connect/join functions.
+
+3. **Actor ownership**: For each actor, only one client should set `isOwnedLocally` to 1.
+
+4. **Remote player rendering**: Create separate actor instances for remote players and update them with `NS_GetRemotePlayerData()`.
+
+5. **Session design**: Use meaningful session names to separate different multiplayer groups.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ u8 NS_JoinSession(const char* session);
 u8 NS_LeaveSession();
 
 // Register an actor for network synchronization
-void NS_SyncActor(Actor* actor, const char* playerID);
+// isOwnedLocally controls whether we push its data or its just a synced actor
+void NS_SyncActor(Actor* actor, const char* playerID, int isOwnedLocally);
 
 // Get the network ID for an actor (returns NULL if not registered)
 const char* NS_GetActorNetworkId(Actor *actor);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Network Play for Zelda 64: Recompiled
+# Network Sync API for Zelda 64: Recompiled
 
 A multiplayer networking framework for Zelda 64: Recompiled that enables Actor synchronization across different game instances.
 
@@ -11,43 +11,21 @@ A multiplayer networking framework for Zelda 64: Recompiled that enables Actor s
 
 This project consists of several components that work together to provide network functionality:
 
-1. **Network Play API** (`network-sync`) - An API mod that exposes networking functionality to other mods
-2. **Network Play Runtime** (`network-sync-runtime`) - A Rust-based dynamic library that implements the networking logic
+1. **Network Sync API** (`network-sync`) - An API mod that exposes networking functionality to other mods
+2. **Network Sync Runtime** (`network-sync-runtime`) - A Rust-based dynamic library that implements the networking logic
 3. **Network Server** (`network-sync-server`) - A webSocket server that handles player connections and data relay
 4. **Test Mod** (`network-sync-test`) - A sample implementation that demonstrates the networking functionality
 
 ## API Reference
 
-The Network Play API provides the following functions to other mods:
+See the full [API Documentation](API.md) for detailed information about available functions and data structures.
 
-### Core Functions
+The Network Play API provides functionality for:
 
-```c
-// Initialize the network play system
-void NS_Init();
-
-// Connect to a network server (returns 1 on success, 0 on failure)
-u8 NS_Connect(const char* host);
-
-// Join a multiplayer session (returns 1 on success, 0 on failure)
-u8 NS_JoinSession(const char* session);
-
-// Leave the current session (returns 1 on success, 0 on failure)
-u8 NS_LeaveSession();
-
-// Register an actor for network synchronization
-// isOwnedLocally controls whether we push its data or its just a synced actor
-void NS_SyncActor(Actor* actor, const char* playerID, int isOwnedLocally);
-
-// Get the network ID for an actor (returns NULL if not registered)
-const char* NS_GetActorNetworkId(Actor *actor);
-
-// Get list of remote player IDs (returns count of players)
-u32 NS_GetRemotePlayerIDs(u32 maxPlayers, char* idsBuffer, u32 idBufferSize);
-
-// Get data for a specific remote player (returns 1 on success, 0 on failure)
-u32 NS_GetRemotePlayerData(const char* playerID, void* dataBuffer);
-```
+- Connecting to network servers
+- Joining and leaving multiplayer sessions
+- Synchronizing actor data across game instances
+- Retrieving information about other players in a session
 
 ### Architecture
 

--- a/network-sync-runtime/src/types.rs
+++ b/network-sync-runtime/src/types.rs
@@ -4,13 +4,15 @@ use serde::{Deserialize, Serialize};
 #[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize, N64MemoryIO)]
 pub struct PlayerData {
+    pub shapeRotation: Vec3s,
+    pub worldPosition: Vec3f,
+
+    // Player Actor specific properties
     pub currentBoots: i8,
     pub currentShield: i8,
     pub _padding: [u8; 2],
-    pub jointTable: [Vec3s; 24], // Might need to increase this in the future
+    pub jointTable: [Vec3s; 24],
     pub upperLimbRot: Vec3s,
-    pub shapeRotation: Vec3s,
-    pub worldPosition: Vec3f,
 }
 
 #[derive(Debug, Clone)]

--- a/network-sync-test/mod.c
+++ b/network-sync-test/mod.c
@@ -19,7 +19,7 @@ RECOMP_IMPORT("mm_network_sync", const char* NS_GetActorNetworkId(Actor *actor))
 RECOMP_IMPORT("mm_network_sync", u32 NS_GetRemotePlayerIDs(u32 maxPlayers, char* idsBuffer, u32 idBufferSize));
 RECOMP_IMPORT("mm_network_sync", u32 NS_GetRemotePlayerData(const char* playerID, void* dataBuffer));
 
-RECOMP_IMPORT("mm_network_sync", void NS_SyncActor(Actor* actor, const char* playerID));
+RECOMP_IMPORT("mm_network_sync", void NS_SyncActor(Actor* actor, const char* playerId, int isOwnedLocally));
 RECOMP_IMPORT("mm_network_sync", void NS_ExtendActorSynced(s16 actor_id, u32 size));
 
 RECOMP_IMPORT("ProxyMM_Notifications", void Notifications_Emit(const char* prefix, const char* msg, const char* suffix));
@@ -97,7 +97,7 @@ void on_play_main(PlayState* play) {
 RECOMP_HOOK("Player_Init")
 void OnPlayerInit(Actor* thisx, PlayState* play) {
     recomp_printf("Player initialized\n");
-    NS_SyncActor(thisx, NULL);
+    NS_SyncActor(thisx, NULL, 1);
 }
 
 // MARK: - Remote Player Actor Processing
@@ -137,7 +137,7 @@ void remote_actors_update(PlayState* play) {
             const char* playerId = remotePlayerIds[i];
             recomp_printf("Creating actor for player %s\n", playerId);
             actor = Actor_SpawnAsChildAndCutscene(&play->actorCtx, play, ACTOR_REMOTE_PLAYER, -9999.0f, -9999.0f, -9999.0f, 0, 0, 0, 0, 0, 0, 0);
-            NS_SyncActor(actor, playerId);
+            NS_SyncActor(actor, playerId, 0);
         }
     }
 

--- a/network-sync/api.c
+++ b/network-sync/api.c
@@ -38,13 +38,15 @@ static NetworkSyncerData* GetActorNetworkData(Actor* actor) {
 // MARK: - Struct
 
 typedef struct {
-    s8 currentBoots;
-    s8 currentShield;
-    u8 _padding[2]; // Add padding for alignment
-    Vec3s jointTable[24]; // Might need to increase this in the future
-    Vec3s upperLimbRot;
     Vec3s shapeRotation;
     Vec3f worldPosition;
+
+    // Player Actor specific properties
+    s8 currentBoots;
+    s8 currentShield;
+    u8 _padding[2];
+    Vec3s jointTable[24];
+    Vec3s upperLimbRot;
 } PlayerSyncData;
 
 // MARK: - Imports

--- a/network-sync/api.c
+++ b/network-sync/api.c
@@ -19,8 +19,12 @@ static u8 gSyncedActorCategories[MAX_ACTOR_CATEGORIES] = {0};  // Bitset for cat
 
 // Structure to hold network-specific data for each actor
 typedef struct {
-    char player_id[64];    // UUID string for this actor
-    u8 is_synced;          // Flag indicating if actor is being synced
+    // UUID string for this actor
+    char player_id[64];
+    // Flag indicating if actor is being synced
+    u8 is_synced;
+    // Flag indicating whether we are in charge of pushing its data to the server
+    u8 is_owned_locally;
 } NetworkSyncerData;
 
 static NetworkSyncerData* GetActorNetworkData(Actor* actor) {
@@ -60,29 +64,30 @@ RECOMP_CALLBACK("*", recomp_after_actor_update)
 void on_actor_update(PlayState* play, Actor* actor) {
     NetworkSyncerData* netData = GetActorNetworkData(actor);
 
-    // Skip actors that aren't being synced or aren't the main player
-    if (netData == NULL || !netData->is_synced || actor->id != 0) {
+    // Skip actors that aren't being synced or aren't locally owned
+    if (netData == NULL || !netData->is_synced || !netData->is_owned_locally) {
         return;
     }
 
-    // Sync the player movement data to the server
-    Player* player = (Player*)actor;
+    // Sync general actor properties
     PlayerSyncData* syncData = recomp_alloc(sizeof(PlayerSyncData) + sizeof(Vec3s) * 23); // For 24 joints
-
-    syncData->currentBoots = player->currentBoots;
-    syncData->currentShield = player->currentShield;
-
-    // Copy each joint individually (assuming jointTable is an array of 24 Vec3s)
-    for (int i = 0; i < 24; i++) {
-        Math_Vec3s_Copy(&syncData->jointTable[i], &player->skelAnime.jointTable[i]);
-    }
-
-    Math_Vec3s_Copy(&syncData->upperLimbRot, &player->upperLimbRot);
     Math_Vec3s_Copy(&syncData->shapeRotation, &actor->shape.rot);
     Math_Vec3f_Copy(&syncData->worldPosition, &actor->world.pos);
 
-    NetworkSyncSendPlayerSync(syncData);
+    // If we have a player, sync player specific properties
+    if (actor->category == ACTORCAT_PLAYER) {
+        Player* player = (Player*)actor;
+        syncData->currentBoots = player->currentBoots;
+        syncData->currentShield = player->currentShield;
 
+        for (int i = 0; i < 24; i++) {
+            Math_Vec3s_Copy(&syncData->jointTable[i], &player->skelAnime.jointTable[i]);
+        }
+
+        Math_Vec3s_Copy(&syncData->upperLimbRot, &player->upperLimbRot);
+    }
+
+    NetworkSyncSendPlayerSync(syncData);
     recomp_free(syncData);
 }
 
@@ -106,12 +111,12 @@ void on_play_main(PlayState* play) {
             Actor* next_actor = actor->next; // Save next pointer before any potential changes
 
             if (net_data != NULL && net_data->is_synced) {
-                if (actor->id == 0) {
+                if (net_data->is_owned_locally) {
                     actor = next_actor;
-                    continue; // Skip local player, continue with next actor
+                    continue; // Skip locally owned actors, continue with next actor
                 }
 
-                // This is a remote actor - check if we have data for it
+                // This is a remotely owned actor - check if we have data for it
                 for (u32 j = 0; j < player_count; j++) {
                     const char* player_id = &ids_buffer[j * 64];
 
@@ -119,21 +124,20 @@ void on_play_main(PlayState* play) {
                         // Found a match, update actor with remote data
                         if (NetworkSyncGetRemotePlayerData(player_id, &remote_data)) {
                             Math_Vec3s_Copy(&actor->shape.rot, &remote_data.shapeRotation);
-
-                            // let's offset the position by just a bit on the x, since we're currently tracking ourselves
                             Math_Vec3f_Copy(&actor->world.pos, &remote_data.worldPosition);
 
-                            // For player actors, update more data
-                            Player* player = (Player*)actor; // hard coded to assume player, should be generalized later.
-                            player->currentBoots = remote_data.currentBoots;
-                            player->currentShield = remote_data.currentShield;
+                            // If we have a player, sync player specific properties
+                            if (actor->category == ACTORCAT_PLAYER) {
+                                Player* player = (Player*)actor;
+                                player->currentBoots = remote_data.currentBoots;
+                                player->currentShield = remote_data.currentShield;
 
-                            // Copy joint table if needed
-                            for (int k = 0; k < 24; k++) {
-                                Math_Vec3s_Copy(&player->skelAnime.jointTable[k], &remote_data.jointTable[k]);
+                                for (int k = 0; k < 24; k++) {
+                                    Math_Vec3s_Copy(&player->skelAnime.jointTable[k], &remote_data.jointTable[k]);
+                                }
+
+                                Math_Vec3s_Copy(&player->upperLimbRot, &remote_data.upperLimbRot);
                             }
-
-                            Math_Vec3s_Copy(&player->upperLimbRot, &remote_data.upperLimbRot);
 
                             break;
                         }
@@ -201,7 +205,7 @@ RECOMP_EXPORT const char* NS_GetActorNetworkId(Actor *actor) {
 
 // MARK: - Syncing
 
-RECOMP_EXPORT void NS_SyncActor(Actor* actor, const char* playerID) {
+RECOMP_EXPORT void NS_SyncActor(Actor* actor, const char* playerId, int isOwnedLocally) {
     if (actor == NULL) {
         recomp_printf("Cannot sync NULL actor\n");
         return;
@@ -221,6 +225,7 @@ RECOMP_EXPORT void NS_SyncActor(Actor* actor, const char* playerID) {
 
     // Mark actor as synced
     netData->is_synced = 1;
+    netData->is_owned_locally = isOwnedLocally;
 
     // Mark this category as containing synced actors
     if (actor->category < MAX_ACTOR_CATEGORIES) {
@@ -237,7 +242,7 @@ RECOMP_EXPORT void NS_SyncActor(Actor* actor, const char* playerID) {
             recomp_printf("Failed to get player ID\n");
         }
     } else {
-        strcpy(netData->player_id, playerID);
+        strcpy(netData->player_id, playerId);
         recomp_printf("Added actor %u to sync system\n", actor->id);
     }
 }


### PR DESCRIPTION
Makes the SyncActor more generic to not be so geared towards (Player *) we now check its type and if its a player we sync more properties. Should now support other actors and sync their positions.

Also introduces a flag for ownership - when an actor is marked as locally own, we'll push data for that actor to the server. If its marked as not locally owned, we expect the server to give us its state which we'll sync.